### PR TITLE
SOF-1615: Set up Dockerfile and publish image workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,31 @@
+name: 'Publish Image'
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionTag:
+        description: 'Version tag (e.g. 46.3.1-staging)'
+        required: true
+        type: 'string'
+
+jobs:
+  publish-image-to-docker-hub:
+    name: 'Publish image to Docker Hub'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Retrieve repository files'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Log in to Docker Hub'
+        uses: 'docker/login-action@v3'
+        with:
+          username: '${{ secrets.DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.DOCKERHUB_PASSWORD }}'
+
+      - name: 'Build and publish Docker image'
+        uses: 'docker/build-push-action@v5'
+        with:
+          context: '.'
+          push: true
+          tags: |
+            tv2media/sofie-server:${{ inputs.versionTag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build phase
+FROM node:20-alpine as BUILD_PHASE
+WORKDIR /opt/sofie-tv2-server
+COPY . .
+RUN yarn install --check-cache --immutable
+RUN yarn build
+RUN yarn workspaces focus --production
+
+# Configuration phase
+FROM node:20-alpine
+WORKDIR /opt/sofie-tv2-server
+COPY --from=BUILD_PHASE /opt/sofie-tv2-server/dist/ ./
+COPY --from=BUILD_PHASE /opt/sofie-tv2-server/node_modules/ ./node_modules/
+
+CMD node .


### PR DESCRIPTION
Adds Dockerfile for building and bundling the Docker image along with the same publish image pipeline as for sofie-server.
Docker Hub secrets are configured for the repository.