### PR TITLE
ci: Fixes wrong Docker image name when publishing to Docker Hub.

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,4 +28,4 @@ jobs:
           context: '.'
           push: true
           tags: |
-            tv2media/sofie-server:${{ inputs.versionTag }}
+            tv2media/sofie-tv2-server:${{ inputs.versionTag }}


### PR DESCRIPTION
Corrects the docker image name.